### PR TITLE
Injection fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
-rvm: 1.9.2
+dist: trusty
+sudo: false
+rvm: 2.2.7
 script: "rake"

--- a/lib/streamy_csv.rb
+++ b/lib/streamy_csv.rb
@@ -30,7 +30,10 @@ module StreamyCsv
   def csv_lines(header_row, &block)
 
     Enumerator.new do |rows|
-      rows << header_row.to_s if header_row
+      def rows.<<(row)
+        super StreamyCsv::InjectionSanitizer.sanitize_csv_row(row).to_s
+      end
+      rows << header_row if header_row
       block.call(rows)
     end
 

--- a/lib/streamy_csv.rb
+++ b/lib/streamy_csv.rb
@@ -1,4 +1,5 @@
 require "streamy_csv/version"
+require "streamy_csv/injection_sanitizer"
 
 module StreamyCsv
 

--- a/lib/streamy_csv/injection_sanitizer.rb
+++ b/lib/streamy_csv/injection_sanitizer.rb
@@ -7,7 +7,7 @@ module StreamyCsv
       if row.is_a?(CSV::Row)
         sanitized_row = row.dup
         row.each do |title, value|
-          if value.start_with?(*PREFIXES_TO_ESCAPE)
+          if value.to_s.start_with?(*PREFIXES_TO_ESCAPE)
             sanitized_row[title] = "#{ESCAPE_CHAR}#{value}"
           end
         end

--- a/lib/streamy_csv/injection_sanitizer.rb
+++ b/lib/streamy_csv/injection_sanitizer.rb
@@ -1,0 +1,18 @@
+module StreamyCsv
+  class InjectionSanitizer
+    PREFIXES_TO_ESCAPE=%w(= @ + - |)
+    ESCAPE_CHAR="'"
+
+    def self.sanitize_csv_row(row)
+      if row.is_a?(CSV::Row)
+        sanitized_row = row.dup
+        row.each do |title, value|
+          if value.start_with?(*PREFIXES_TO_ESCAPE)
+            sanitized_row[title] = "#{ESCAPE_CHAR}#{value}"
+          end
+        end
+      end
+      row
+    end
+  end
+end

--- a/lib/streamy_csv/version.rb
+++ b/lib/streamy_csv/version.rb
@@ -1,3 +1,3 @@
 module StreamyCsv
-  VERSION = "0.3.0"
+  VERSION = "0.5.2"
 end

--- a/spec/lib/streamy_csv/injection_sanitizer_spec.rb
+++ b/spec/lib/streamy_csv/injection_sanitizer_spec.rb
@@ -1,0 +1,39 @@
+$: << File.join(File.dirname(__FILE__), "../../../lib")
+require 'streamy_csv/injection_sanitizer'
+require 'csv'
+
+describe StreamyCsv::InjectionSanitizer do
+  describe 'sanitize_csv_row' do
+    it "returns the data as is in case it's not a csv row" do
+      StreamyCsv::InjectionSanitizer.sanitize_csv_row(10).should == 10
+    end
+
+    it 'escapes the leading escape leading | character on any column' do
+      row = CSV::Row.new([:x], ["|RAND()"])
+      sanitized_row = StreamyCsv::InjectionSanitizer.sanitize_csv_row(row)
+      sanitized_row.to_s.strip.should == "'|RAND()"
+    end
+
+    it 'escapes the leading escape leading + character on any column' do
+      row = CSV::Row.new([:x], ["-RAND()"])
+      sanitized_row = StreamyCsv::InjectionSanitizer.sanitize_csv_row(row)
+      sanitized_row.to_s.strip.should == "'-RAND()"
+    end
+
+    it 'escapes the leading escape leading + character on any column' do
+      row = CSV::Row.new([:x], ["+RAND()"])
+      sanitized_row = StreamyCsv::InjectionSanitizer.sanitize_csv_row(row)
+      sanitized_row.to_s.strip.should == "'+RAND()"
+    end
+    it 'escapes the leading escape leading @ character on any column' do
+      row = CSV::Row.new([:x], ["@RAND()"])
+      sanitized_row = StreamyCsv::InjectionSanitizer.sanitize_csv_row(row)
+      sanitized_row.to_s.strip.should == "'@RAND()"
+    end
+    it 'escapes the leading escape leading = character on any column' do
+      row = CSV::Row.new([:x], ["=RAND()"])
+      sanitized_row = StreamyCsv::InjectionSanitizer.sanitize_csv_row(row)
+      sanitized_row.to_s.strip.should == "'=RAND()"
+    end
+  end
+end

--- a/spec/streamy_csv_spec.rb
+++ b/spec/streamy_csv_spec.rb
@@ -34,14 +34,14 @@ describe StreamyCsv do
     it 'sets the streaming headers' do
       @controller.stream_csv('abc.csv', @header)
       @controller.headers.should include({'X-Accel-Buffering' => 'no',
-        "Cache-Control" => "no-cache"
+                                          "Cache-Control" => "no-cache"
       })
     end
 
     it 'sets the file headers' do
       @controller.stream_csv('abc.csv', @header)
       @controller.headers.should include({"Content-Type" => "text/csv",
-        "Content-disposition" => "attachment; filename=\"abc.csv\""
+                                          "Content-disposition" => "attachment; filename=\"abc.csv\""
       })
     end
 
@@ -58,6 +58,26 @@ describe StreamyCsv do
 
       @controller.response.status.should == 200
       @controller.response_body.is_a?(Enumerator).should == true
+    end
+
+    it 'sanitizes header and contents and streams the csv file' do
+      header = CSV::Row.new([:name, :title], ['Name', "=cmd|' /C"], true)
+
+      @controller.stream_csv('abc.csv', header) do |rows|
+        rows << CSV::Row.new([:name, :title], ['AB', 'Mr'])
+        rows << CSV::Row.new([:name, :title], ["=cmd|' /C", '-Pres'])
+        rows << CSV::Row.new([:name, :title], ["@something", '+Pres'])
+      end
+
+      @controller.response.status.should == 200
+      @controller.response_body.is_a?(Enumerator).should == true
+      body = @controller.response_body.to_a
+      body.size.should == 4
+
+      body[0].to_s.strip.should == "Name,'=cmd|' /C"
+      body[1].to_s.strip.should == "AB,Mr"
+      body[2].to_s.strip.should == "'=cmd|' /C,'-Pres"
+      body[3].to_s.strip.should == "'@something,'+Pres"
     end
   end
 


### PR DESCRIPTION
Escapes all leading occurrences of `= + - @ |` in the cells. Always. To prevent injection / malicious content from being executed when someone opens the file on Excel.